### PR TITLE
Fix broken links in profile README (v1 → main, contributing URL)

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -42,7 +42,7 @@
   <a href="https://cocoindex.io/cocoindex-code" title="CocoIndex-code — flagship MCP server for AI coding agents: AST-aware, incremental, semantic code index. Claude Code and Cursor see your whole repo instantly."><picture><source media="(prefers-color-scheme: dark)" srcset="https://cocoindex.io/blobs/github/homepage/cocoindex-code-hero-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cocoindex.io/blobs/github/homepage/cocoindex-code-hero-light.svg"><img src="https://cocoindex.io/blobs/github/homepage/cocoindex-code-hero-light.svg" alt="CocoIndex-code — flagship MCP server for AI coding agents. AST-aware incremental semantic code index that keeps live call graphs, symbols, vectors, and chunks fresh on every commit. 70% fewer tokens per turn, 80-90% cache hits on re-index, sub-second freshness. Supports Python, TypeScript, Rust, and Go. Features: Δ-only incremental processing, semantic search by meaning (not grep), call graphs and blast-radius analysis, global repo view for duplicates and architecture. Build coding agents (generate, refactor) and code-review agents (catch, approve). One install — Claude Code, Cursor, and other MCP-aware agents see your whole repository instantly. Keywords: MCP server, coding agent, code intelligence, AST chunking, semantic code search, call graph, vector embedding, repository context, Claude Code, Cursor, incremental indexing, blast radius." width="100%"/></picture></a>
 </p>
 
-<p align="center"><a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples"><b>See all 20+ examples · updated every week →</b></a></p>
+<p align="center"><a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all 20+ examples · updated every week →</b></a></p>
 
 <br/><br/>
 
@@ -105,40 +105,40 @@
 
 <h2 align="center">What can you <em>build?</em></h2>
 
-<p align="center"><a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples"><b>See all 20+ examples · updated every week →</b></a></p>
+<p align="center"><a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples"><b>See all 20+ examples · updated every week →</b></a></p>
 
-<p align="center"><b>Working starters from <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples">the examples tree</a> — clone, plug your source, ship.</b></p>
+<p align="center"><b>Working starters from <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples">the examples tree</a> — clone, plug your source, ship.</b></p>
 
 <p align="center">
-  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/code_embedding" title="Real-time code index"><img src="https://cocoindex.io/blobs/github/homepage/example-code.svg" alt="Real-time code index — walk a git repo, AST-chunk source files, embed with sentence-transformers, upsert to pgvector / LanceDB, incremental on every commit." width="70%"/></a>
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples/code_embedding" title="Real-time code index"><img src="https://cocoindex.io/blobs/github/homepage/example-code.svg" alt="Real-time code index — walk a git repo, AST-chunk source files, embed with sentence-transformers, upsert to pgvector / LanceDB, incremental on every commit." width="70%"/></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/pdf_embedding" title="PDF → RAG index"><img src="https://cocoindex.io/blobs/github/homepage/example-pdf.svg" alt="PDF → RAG index — ingest PDFs from local, S3, or GDrive, extract + chunk text, embed chunks, upsert to pgvector / LanceDB. Classic retrieval-augmented-generation stack, incremental." width="70%"/></a>
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples/pdf_embedding" title="PDF → RAG index"><img src="https://cocoindex.io/blobs/github/homepage/example-pdf.svg" alt="PDF → RAG index — ingest PDFs from local, S3, or GDrive, extract + chunk text, embed chunks, upsert to pgvector / LanceDB. Classic retrieval-augmented-generation stack, incremental." width="70%"/></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/hn_trending_topics" title="HN trending topics"><img src="https://cocoindex.io/blobs/github/homepage/example-hn-trending.svg" alt="HN trending topics — pull Hacker News threads via Algolia, recursively parse comments, LLM-extract topics with Gemini 2.5 Flash, rank by weighted hit count, store in Postgres. Incremental." width="70%"/></a>
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples/hn_trending_topics" title="HN trending topics"><img src="https://cocoindex.io/blobs/github/homepage/example-hn-trending.svg" alt="HN trending topics — pull Hacker News threads via Algolia, recursively parse comments, LLM-extract topics with Gemini 2.5 Flash, rank by weighted hit count, store in Postgres. Incremental." width="70%"/></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/conversation_to_knowledge" title="Conversation → knowledge graph"><img src="https://cocoindex.io/blobs/github/homepage/example-kg.svg" alt="Conversation → knowledge graph — LLM extracts people, topics, decisions, action items from transcripts and upserts into Neo4j / Kuzu. Live graph, incremental." width="70%"/></a>
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples/conversation_to_knowledge" title="Conversation → knowledge graph"><img src="https://cocoindex.io/blobs/github/homepage/example-kg.svg" alt="Conversation → knowledge graph — LLM extracts people, topics, decisions, action items from transcripts and upserts into Neo4j / Kuzu. Live graph, incremental." width="70%"/></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/multi_codebase_summarization" title="Multi-repo summarization"><img src="https://cocoindex.io/blobs/github/homepage/example-multicode.svg" alt="Multi-repo summarization — walk N git repos, extract structure, LLM-summarize per-repo + a rolled-up org summary, refresh on every push." width="70%"/></a>
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples/multi_codebase_summarization" title="Multi-repo summarization"><img src="https://cocoindex.io/blobs/github/homepage/example-multicode.svg" alt="Multi-repo summarization — walk N git repos, extract structure, LLM-summarize per-repo + a rolled-up org summary, refresh on every push." width="70%"/></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/patient_intake_extraction_baml" title="Structured extraction"><img src="https://cocoindex.io/blobs/github/homepage/example-intake.svg" alt="Structured extraction — BAML / DSPy typed schema extraction from forms, PDFs, intakes, invoices into Postgres / warehouse. Incremental." width="70%"/></a>
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples/patient_intake_extraction_baml" title="Structured extraction"><img src="https://cocoindex.io/blobs/github/homepage/example-intake.svg" alt="Structured extraction — BAML / DSPy typed schema extraction from forms, PDFs, intakes, invoices into Postgres / warehouse. Incremental." width="70%"/></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/conversation_to_knowledge" title="Podcast → knowledge graph"><img src="https://cocoindex.io/blobs/github/homepage/example-podcast.svg" alt="Podcast → knowledge graph — transcribe YouTube / Spotify audio with speaker diarization, LLM-extract speakers and statements, resolve entities across episodes, store in SurrealDB / Neo4j." width="70%"/></a>
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples/conversation_to_knowledge" title="Podcast → knowledge graph"><img src="https://cocoindex.io/blobs/github/homepage/example-podcast.svg" alt="Podcast → knowledge graph — transcribe YouTube / Spotify audio with speaker diarization, LLM-extract speakers and statements, resolve entities across episodes, store in SurrealDB / Neo4j." width="70%"/></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/cocoindex-io/cocoindex/tree/v1/examples/csv_to_kafka" title="CSV → Kafka live"><img src="https://cocoindex.io/blobs/github/homepage/example-csv-kafka.svg" alt="CSV → Kafka live — watch a folder of CSV files, publish each row as a JSON message to a Kafka topic via CocoIndex's Kafka target connector. Incremental, sub-second, no producer loop." width="70%"/></a>
+  <a href="https://github.com/cocoindex-io/cocoindex/tree/main/examples/csv_to_kafka" title="CSV → Kafka live"><img src="https://cocoindex.io/blobs/github/homepage/example-csv-kafka.svg" alt="CSV → Kafka live — watch a folder of CSV files, publish each row as a JSON message to a Kafka topic via CocoIndex's Kafka target connector. Incremental, sub-second, no producer loop." width="70%"/></a>
 </p>
 
 <br/>
@@ -169,7 +169,7 @@
 </table>
 
 <p align="center">
-  📝 <a href="https://cocoindex.io/docs/about/contributing"><b>Contributing guide</b></a> &nbsp;·&nbsp;
+  📝 <a href="https://cocoindex.io/docs/contributing/guide/"><b>Contributing guide</b></a> &nbsp;·&nbsp;
   🐛 <a href="https://github.com/cocoindex-io/cocoindex/labels/good%20first%20issue"><b>good first issues</b></a> &nbsp;·&nbsp;
   💬 <a href="https://discord.com/invite/zpA9S2DR7s"><b>Say hi on Discord</b></a>
 </p>


### PR DESCRIPTION
## Summary
- Repoint all 11 example links in `profile/README.md` from `cocoindex/tree/v1/...` to `cocoindex/tree/main/...` (the `v1` branch is gone — everything merged into `main`).
- Fix the Contributing guide link from the 404 `cocoindex.io/docs/about/contributing` to the correct `cocoindex.io/docs/contributing/guide/`.

## Test plan
- All 71 URLs in `profile/README.md` were validated with `curl`; every one returns 200.
